### PR TITLE
Added buffer pool to NIOTSConnectionChannel

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "NIOTransportServices", targets: ["NIOTransportServices"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
     targets: [

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -231,11 +231,11 @@ internal final class NIOTSConnectionChannel: StateManagedNWConnectionChannel {
 
     /// A lock that guards the _addressCache.
     internal let _addressCacheLock = NIOLock()
-    
-    /// The `PooledRecvBufferAllocator` used to allocate buffers for incoming data
-    internal var recvBufferPool: PooledRecvBufferAllocator
-    
-    /// A constant to hold the maximum amount of buffers that should be created by the `PooledRecvBufferAllocator`
+
+    /// The `NIOPooledRecvBufferAllocator` used to allocate buffers for incoming data
+    internal var recvBufferPool: NIOPooledRecvBufferAllocator
+
+    /// A constant to hold the maximum amount of buffers that should be created by the `NIOPooledRecvBufferAllocator`
     ///
     /// Once we allow multiple messages per read on the channel, this should become a `maxMessagesPerRead` property
     /// and a corresponding channel option that users can configure.
@@ -418,11 +418,11 @@ extension NIOTSConnectionChannel {
             // It would be nice if we didn't have to do this copy, but I'm not sure how to avoid it with the current Data
             // APIs.
             let (buffer, bytesReceived) = self.recvBufferPool.buffer(allocator: allocator) { $0.writeBytes(content) }
-            
+
             self.recvBufferPool.record(actualReadBytes: bytesReceived)
             self.pipeline.fireChannelRead(NIOAny(buffer))
             self.pipeline.fireChannelReadComplete()
-            
+
         }
 
         // Next, we want to check if there's an error. If there is, we're going to deliver it, and then close the connection with

--- a/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
+++ b/Sources/NIOTransportServices/NIOTSConnectionChannel.swift
@@ -415,6 +415,8 @@ extension NIOTSConnectionChannel {
 
         // First things first, if there's data we need to deliver it.
         if let content = content {
+            // It would be nice if we didn't have to do this copy, but I'm not sure how to avoid it with the current Data
+            // APIs.
             let (buffer, bytesReceived) = self.recvBufferPool.buffer(allocator: allocator) { $0.writeBytes(content) }
             
             self.recvBufferPool.record(actualReadBytes: bytesReceived)


### PR DESCRIPTION
Added buffer pool to NIOTSConnectionChannel for reading messages.

### Motivation:

In order to avoid creating a new `ByteBuffer` for every single message read from the channel, we decided to reuse the `PooledRecvBufferAllocator` type from `NIOCore` to leverage a pool of buffers. 

### Modifications:

Used the buffer allocation mechanism provided by the `PooledRecvBufferAllocator` to reuse and adapt previously created receive buffers. 

### Result:

Channel reads can now reuse previously created buffers, avoiding unnecessary overhead by creating new buffers every single time.
